### PR TITLE
#fixes : it does not consider the case where the machine is running Windows on ARM

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,8 +6,11 @@
  *
  * @name isWin
  * @function
- * @return {Boolean} `true`, if the platform is Windows, `false` otherwise.
+ * @return {Boolean}`true`, if the platform is Windows and the architecture is not ARM, `false` otherwise.
  */
 module.exports = function isWin () {
-    return process.platform === "win32";
+    return (process.platform === "win32") && (process.arch !== "arm");
 };
+
+
+

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "bloggify.js",
     "bloggify.json",
     "bloggify/"
-  ]
+  ],
+  "contributors": [
+    "Gaurav Kumar Kashyap <gauravkumarkashyap74354@gmail.com>"
+ ]
 }

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,8 @@ const tester = require("tester")
     ;
 
 tester.describe("is-win", t => {
-    t.should("check if it's windows or not", () => {
-        t.expect(isWin()).toBe(process.platform === "win32");
+    t.should("check if it's windows or not on x86/x64", () => {
+        t.expect(isWin()).toBe((process.platform === "win32") && (process.arch !== "arm"));
     });
 });
+      


### PR DESCRIPTION
The bug in the isWin() function is that it does not consider the case where the machine is running Windows on ARM. To fix the bug, we need to add a check for the process.arch property and return false if the machine is running Windows on ARM.